### PR TITLE
adds namespace separator

### DIFF
--- a/src/Console/MakeProviderCommand.php
+++ b/src/Console/MakeProviderCommand.php
@@ -116,7 +116,7 @@ class MakeProviderCommand extends Command
         $contents = json_decode(file_get_contents($filename = base_path('composer.json')), true);
 
         $providerName = $compiler->getContext()->nameStudlyCase();
-        $contents['autoload']['psr-4']["SocialiteProviders\\$providerName"] = "SocialiteProviders/$providerName/src/";
+        $contents['autoload']['psr-4']["SocialiteProviders\\$providerName\\"] = "SocialiteProviders/$providerName/src/";
 
         file_put_contents($filename, json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }


### PR DESCRIPTION
Fixes an:
> [InvalidArgumentException]
> A non-empty PSR-4 prefix must end with a namespace separator.