### PR TITLE
Change fire() to handle() for Laravel 5.5

### DIFF
--- a/src/Console/MakeProviderCommand.php
+++ b/src/Console/MakeProviderCommand.php
@@ -36,7 +36,7 @@ class MakeProviderCommand extends Command
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         $data = [
             'name'            => $this->argument('name'),


### PR DESCRIPTION
In Laravel 5.5, the method fire() was changed to handle().

Now the command `php artisan make:socialite` can be used again.

https://laravel.com/docs/5.5/upgrade - ctrl+f 'fire'.