### PR TITLE
Update composer.json for support Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "illuminate/console": "5.5.* || 5.6.*"
+        "php": "^5.6 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Delete         "illuminate/console": "5.5.* || 5.6.*" requirements

I don't know how to put require illuminate/console, on Laravel 5.7, but U tested (install, and run) and work fine.

```
php artisan make:socialite Castris --spec=oauth2 --author=YourName --email=your@name.com --scopes=basic --authorize_url=http://myapp.io/oauth/authorize --access_token_url=http://myapp.io/oauth/access_token --user_details_url=http://myapp.io/users/me
```

