### PR TITLE
Add support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
-        "illuminate/console": "5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 "
+        "illuminate/console": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Adds support for PHP ^8.0
- Removes support for old PHP versions (5.x)
- Removes support for old Illuminate packages (< 7.x)

Resolves https://github.com/SocialiteProviders/Generators/issues/34