### PR TITLE
Elevate socialiteproviders/manager requirements 

### DIFF
--- a/src/stubs/composer.blade.php
+++ b/src/stubs/composer.blade.php
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/{{ $nameLowerCase }}",
     "description": "{{ $nameStudlyCase }} {{ $oauthVersion }} Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "{{ $authorName }}",
-        "email": "{{ $authorMail }}"
-    }],
+    "authors": [
+        {
+            "name": "{{ $authorName }}",
+            "email": "{{ $authorMail }}"
+        }
+    ],
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR elevates `socialiteproviders/manager` requirements to `^4.2`

---

See https://github.com/SocialiteProviders/Providers/pull/899 and https://github.com/SocialiteProviders/Providers/pull/882