### PR TITLE
Update dependencies for Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/console": "^9.0 || ^10.0 || ^11.0 "
+        "illuminate/console": "^9.0 || ^10.0 || ^11.0 | ^12.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
What:
- Extend supported versions of illuminate/console to include ^12.0

Why:
Ensure compatibility with Laravel 12